### PR TITLE
we should use the reconstructed g4 and g6

### DIFF
--- a/magma/reconstruction.m
+++ b/magma/reconstruction.m
@@ -155,12 +155,12 @@ else
     g4 := elts[1]; g6 := elts[2];
 end if;
 
-R<x> := PolynomialRing(L); f := (4*x^3 - g4*x - g6)/4; h := 0;
+R<x> := PolynomialRing(L);
+f := (4*x^3 - g4*x - g6)/4; h := 0;
 X := HyperellipticCurve(f);
 
-R<x> := PolynomialRing(CC);
-fCC := (4*x^3 - g4CC*x - g6CC)/4; hCC := R ! 0;
-YCC := RiemannSurface(fCC, 2 : Precision := Precision(CC) + 10);
+fCC := EmbedPolynomialExtra(f);
+YCC := RiemannSurface(fCC, 2 : Precision := Precision(CC));
 Q := ChangeRing(YCC`BigPeriodMatrix, CC) / 2;
 
 /* The next line functions as an assertion */


### PR DESCRIPTION
This fixes a bug reported by @andrewvsutherland

First of all let me define the curve:
```
> Genus2Elliptic2("11a1","11a2")[1];
Hyperelliptic Curve defined by y^2 + (x^3 + x^2 + x + 1)*y = -36*x^6 - 413*x^5 - 682*x^4 + 4209*x^3 - 1996*x^2 - 1658*x - 252 over Rational Field
```


Before PR
```
for i in {1..20}; do echo 's := GetSeed(); foo := HeuristicDecomposition(Genus2Elliptic2("11a1","11a2")[1]); s, assigned foo;' | magma -b -S $i ; done
Runtime error: Error in determining tangent representation: 1.6051E-100
1 false
2 true
Runtime error: Error in determining tangent representation: 1.4641E-100
3 false
Runtime error: Error in determining tangent representation: 1.4342E-100
4 false
Runtime error: Error in determining tangent representation: 1.6664E-100
5 false
Runtime error: Error in determining tangent representation: 1.3629E-100
6 false
Runtime error: Error in determining tangent representation: 3.1825E-100
7 false
8 true
9 true
Runtime error: Error in determining tangent representation: 1.6664E-100
10 false
Runtime error: Error in determining tangent representation: 1.6963E-100
11 false
Runtime error: Error in determining tangent representation: 2.1409E-100
12 false
13 true
14 true
15 true
Runtime error: Error in determining tangent representation: 2.3631E-100
16 false
Runtime error: Error in determining tangent representation: 3.1825E-100
17 false
18 true
19 true
20 true
```
after PR they all succeed
